### PR TITLE
chore: bump go.pkg.auto-ci.yml pin to v1.0.105

### DIFF
--- a/.github/workflows/go.pkg.auto-ci.yml
+++ b/.github/workflows/go.pkg.auto-ci.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   go-auto-ci:
-    uses:  tommzn/github-ci/.github/workflows/go.pkg.auto-ci.yml@v1.0.100
+    uses:  tommzn/github-ci/.github/workflows/go.pkg.auto-ci.yml@v1.0.105

--- a/.github/workflows/go.pkg.auto-ci.yml
+++ b/.github/workflows/go.pkg.auto-ci.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   go-auto-ci:
-    uses:  tommzn/github-ci/.github/workflows/go.pkg.auto-ci.yml@v1.0.105
+    uses:  tommzn/github-ci/.github/workflows/go.pkg.auto-ci.yml@v1.0.106


### PR DESCRIPTION
Bumps the pinned `tommzn/github-ci` reusable workflow reference from `@v1.0.100` to `@v1.0.105`.

That tag includes [tommzn/github-ci#1](https://github.com/tommzn/github-ci/pull/1):
- `go.pkg.auto-ci.yml` now splits into two permission-scoped jobs (`test`: `contents: read`, `release`: `contents: write`) instead of running both under the same broad write permission — the test job no longer runs with write access on `pull_request` events.
- `actions/checkout` bumped from `v4` to `v7`.
- The release job now also gates directly on `refs/heads/main` or `refs/heads/master`, not just via the caller.

No behavior change expected for this repo beyond the tightened permissions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wh66hc9pHeyjcXpiuh6Fxn)_