### PR TITLE
chore: bump go.pkg.auto-ci.yml pin to v1.0.107

### DIFF
--- a/.github/workflows/go.pkg.auto-ci.yml
+++ b/.github/workflows/go.pkg.auto-ci.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   go-auto-ci:
-    uses:  tommzn/github-ci/.github/workflows/go.pkg.auto-ci.yml@v1.0.106
+    uses:  tommzn/github-ci/.github/workflows/go.pkg.auto-ci.yml@v1.0.107


### PR DESCRIPTION
Bumps the pinned `tommzn/github-ci` reusable workflow reference from `@v1.0.106` to `@v1.0.107`.

That tag includes [tommzn/github-ci#3](https://github.com/tommzn/github-ci/pull/3):
- Fixed the "Get Go version" regex, which previously failed to match a three-part `go.mod` directive (e.g. `go 1.25.0`) and silently fell back to whatever Go was preinstalled on the runner. This repo's `go.mod` declares `go 1.25.9` and was passing only by luck — the runner's preinstalled Go happened to satisfy that floor.
- Added a fail-loud check: if `goversion` can't be determined, the step now exits 1 with an `::error::` annotation instead of continuing silently.

No behavior change expected beyond the more robust version detection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wh66hc9pHeyjcXpiuh6Fxn)_