### PR TITLE
feat: make WithContext/WithFields immutable (GL-2, GL-3, GL-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,30 @@ logger.Logf(log.Error, "failed: %s", err)
 
 ### Log context
 
-Attach key/value metadata to every log message via a standard `context.Context`:
+Attach key/value metadata to every log message via a standard `context.Context`.
+`WithContext` and `WithFields` return a *new* Logger rather than modifying the
+one they're called on, so a single base logger can safely be shared across
+goroutines - derive a per-request logger from it instead of mutating it in place:
 
 ```go
+logger := log.NewLogger(log.Debug, nil, nil) // one shared base logger
+
+// per request/goroutine:
 ctx := log.LogContextWithValues(context.Background(), map[string]string{
     "requestid": "abc-123",
     "env":       "production",
 })
-logger.WithContext(ctx)
-logger.Info("context is now attached to all subsequent messages")
+requestLogger := logger.WithContext(ctx)
+requestLogger.Info("context is now attached to this logger only")
+
+// or attach fields directly, without going through a context.Context:
+requestLogger = logger.WithFields(map[string]string{"requestid": "abc-123"})
 ```
 
 ### Utility helpers
+
+Like `WithContext`/`WithFields`, all of these return a new Logger and leave the one
+passed in unchanged:
 
 ```go
 // Attach a namespace label

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"sort"
@@ -28,9 +29,11 @@ func newEmptyLogContext() LogContext {
 }
 
 // LogContextWithValues adds passed log values to passed context.
+// The passed values map is copied, not aliased - mutating it after this call
+// has no effect on the returned context.
 func LogContextWithValues(ctx context.Context, values map[string]string) context.Context {
 
-	logContext := newLogContext(values)
+	logContext := newLogContext(maps.Clone(values))
 	if currentLogContext, ok := ctx.Value(logContextKey).(LogContext); ok {
 		logContext = logContext.AppendValues(currentLogContext.values)
 	}
@@ -47,14 +50,19 @@ func getLogContext(ctx context.Context) LogContext {
 	return newLogContext(make(map[string]string))
 }
 
-// AppendValues reads values from current log context, append passed values and returns a new log context.
+// AppendValues reads values from current log context, appends passed values to a copy
+// and returns a new log context. Neither the receiver's nor the passed values map is
+// mutated.
 func (logContext LogContext) AppendValues(values map[string]string) LogContext {
 
-	currentValues := logContext.values
-	for key, value := range values {
-		currentValues[key] = value
+	merged := maps.Clone(logContext.values)
+	if merged == nil {
+		merged = make(map[string]string, len(values))
 	}
-	return newLogContext(currentValues)
+	for key, value := range values {
+		merged[key] = value
+	}
+	return newLogContext(merged)
 }
 
 // String creates a string representation of internal values map.

--- a/context_test.go
+++ b/context_test.go
@@ -55,8 +55,38 @@ func (suite *ContextTestSuite) TestAppendValues() {
 
 	logContext := newLogContext(suite.contextValuesForTest())
 	suite.Len(logContext.values, 2)
-	logContext.AppendValues(additionalContextValues)
-	suite.Len(logContext.values, 3)
+
+	merged := logContext.AppendValues(additionalContextValues)
+
+	// AppendValues returns a new LogContext rather than mutating the receiver.
+	suite.Len(logContext.values, 2)
+	suite.Len(merged.values, 3)
+}
+
+func (suite *ContextTestSuite) TestAppendValuesDoesNotMutatePassedMap() {
+
+	logContext := newLogContext(suite.contextValuesForTest())
+
+	additionalContextValues := make(map[string]string)
+	additionalContextValues["Key3"] = "Value3"
+
+	_ = logContext.AppendValues(additionalContextValues)
+
+	suite.Len(additionalContextValues, 1)
+	_, ok := additionalContextValues["Key1"]
+	suite.False(ok)
+}
+
+func (suite *ContextTestSuite) TestLogContextWithValuesDoesNotMutateCallerMap() {
+
+	// Regression test for GL-3: LogContextWithValues used to write the parent
+	// context's values directly into the caller-supplied map.
+	parentCtx := LogContextWithValues(context.Background(), map[string]string{"parent_key": "parent_val"})
+
+	myValues := map[string]string{"foo": "bar"}
+	_ = LogContextWithValues(parentCtx, myValues)
+
+	suite.Equal(map[string]string{"foo": "bar"}, myValues)
 }
 
 func (suite *ContextTestSuite) TestDefaultContextForNodes() {

--- a/formatter.go
+++ b/formatter.go
@@ -3,6 +3,7 @@ package log
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 )
 
@@ -22,9 +23,13 @@ func newLogzioJsonFormatter() LogFormatter {
 }
 
 // format composes passed log level, context and message in a map and marshal it to JSON.
+// Builds its own copy of the context values rather than writing into logContext.values
+// directly - that map is the same instance a *LogHandler keeps for every message it logs,
+// so mutating it here would race with concurrent log calls on the same logger.
 func (formatter *LogzioJsonFormatter) format(logLevel LogLevel, logContext LogContext, message string) string {
 
-	ctxValues := logContext.values
+	ctxValues := make(map[string]string, len(logContext.values)+3)
+	maps.Copy(ctxValues, logContext.values)
 	ctxValues[LogCtxLogLevel] = logLevel.String()
 	ctxValues["@timestamp"] = time.Now().UTC().Format(LOGZIO_TIMESTAMP_FORMAT)
 	ctxValues[LogCtxMessage] = message

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,8 +8,15 @@ import (
 // Logger is an infterface for different types of logger.
 type Logger interface {
 
-	// WithContext sets a given log context.
-	WithContext(context.Context)
+	// WithContext returns a new Logger with the log context from the given
+	// context.Context attached. The receiver is left unchanged, so it's safe
+	// to call concurrently on a logger shared across goroutines - assign the
+	// result rather than relying on WithContext to mutate the logger in place.
+	WithContext(context.Context) Logger
+
+	// WithFields returns a new Logger with the given key/value pairs merged
+	// into its log context. The receiver is left unchanged.
+	WithFields(fields map[string]string) Logger
 
 	// Statusf logs a formated message with log level Status.
 	Statusf(message string, v ...interface{})
@@ -23,16 +30,16 @@ type Logger interface {
 	// Error logs given message with log level Error.
 	Error(v ...interface{})
 
-	// Errorf logs a formated message with log level Info.
+	// Infof logs a formated message with log level Info.
 	Infof(message string, v ...interface{})
 
-	// Error logs given message with log level Info.
+	// Info logs given message with log level Info.
 	Info(v ...interface{})
 
-	// Errorf logs a formated message with log level Debug.
+	// Debugf logs a formated message with log level Debug.
 	Debugf(message string, v ...interface{})
 
-	// Error logs given message with log level Debug.
+	// Debug logs given message with log level Debug.
 	Debug(v ...interface{})
 
 	// Logs a formated message with given log level.

--- a/interfaces.go
+++ b/interfaces.go
@@ -9,9 +9,12 @@ import (
 type Logger interface {
 
 	// WithContext returns a new Logger with the log context from the given
-	// context.Context attached. The receiver is left unchanged, so it's safe
-	// to call concurrently on a logger shared across goroutines - assign the
-	// result rather than relying on WithContext to mutate the logger in place.
+	// context.Context merged into its existing context (values from ctx win
+	// on key conflicts) - fields already attached via WithFields or similar
+	// are preserved, not discarded. The receiver is left unchanged, so it's
+	// safe to call concurrently on a logger shared across goroutines - assign
+	// the result rather than relying on WithContext to mutate the logger in
+	// place.
 	WithContext(context.Context) Logger
 
 	// WithFields returns a new Logger with the given key/value pairs merged

--- a/logger.go
+++ b/logger.go
@@ -3,13 +3,17 @@ package log
 import (
 	"context"
 	"fmt"
-	"sync"
 )
 
 // LogHandler provides methods to log messges with different log level
 // and takes care about formatting and shipping logs.
+//
+// A *LogHandler is immutable once constructed: logLevel and context are never
+// modified after creation, so a single instance can safely be shared across
+// goroutines and read concurrently by log() without locking. WithContext and
+// WithFields don't mutate the receiver - they return a new *LogHandler that
+// shares the same formatter and shipper.
 type LogHandler struct {
-	mu        sync.RWMutex
 	logLevel  LogLevel
 	context   LogContext
 	formatter LogFormatter
@@ -24,21 +28,31 @@ func (logger *LogHandler) logf(logLevel LogLevel, message string, v ...interface
 // log will create a log message with given values.
 func (logger *LogHandler) log(logLevel LogLevel, v ...interface{}) {
 
-	logger.mu.RLock()
-	level := logger.logLevel
-	ctx := logger.context
-	logger.mu.RUnlock()
-
-	if level >= logLevel {
-		logger.shipper.send(logger.formatter.format(logLevel, ctx, fmt.Sprint(v...)))
+	if logger.logLevel >= logLevel {
+		logger.shipper.send(logger.formatter.format(logLevel, logger.context, fmt.Sprint(v...)))
 	}
 }
 
-// WithContext applies the log context.
-func (logger *LogHandler) WithContext(ctx context.Context) {
-	logger.mu.Lock()
-	logger.context = getLogContext(ctx)
-	logger.mu.Unlock()
+// WithContext returns a new Logger with the log context from the given
+// context.Context attached. The receiver is left unchanged.
+func (logger *LogHandler) WithContext(ctx context.Context) Logger {
+	return &LogHandler{
+		logLevel:  logger.logLevel,
+		context:   getLogContext(ctx),
+		formatter: logger.formatter,
+		shipper:   logger.shipper,
+	}
+}
+
+// WithFields returns a new Logger with the given key/value pairs merged into
+// its log context. The receiver is left unchanged.
+func (logger *LogHandler) WithFields(fields map[string]string) Logger {
+	return &LogHandler{
+		logLevel:  logger.logLevel,
+		context:   logger.context.AppendValues(fields),
+		formatter: logger.formatter,
+		shipper:   logger.shipper,
+	}
 }
 
 // Statusf format given log message for log level Status.

--- a/logger.go
+++ b/logger.go
@@ -34,11 +34,14 @@ func (logger *LogHandler) log(logLevel LogLevel, v ...interface{}) {
 }
 
 // WithContext returns a new Logger with the log context from the given
-// context.Context attached. The receiver is left unchanged.
+// context.Context merged into its existing context - matching WithFields'
+// merge semantics rather than discarding fields already attached to the
+// receiver (e.g. via a prior WithFields/WithNameSpace call). Values from ctx
+// win on key conflicts. The receiver is left unchanged.
 func (logger *LogHandler) WithContext(ctx context.Context) Logger {
 	return &LogHandler{
 		logLevel:  logger.logLevel,
-		context:   getLogContext(ctx),
+		context:   logger.context.AppendValues(getLogContext(ctx).values),
 		formatter: logger.formatter,
 		shipper:   logger.shipper,
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -90,7 +92,7 @@ func (suite *LoggerTestSuite) TestLoggingWithContext() {
 	contextValues["Key2"] = "Value2"
 	ctx := LogContextWithValues(context.Background(), contextValues)
 	logger := NewLogger(Debug, nil, shipper)
-	logger.WithContext(ctx)
+	logger = logger.WithContext(ctx)
 
 	expectedNumberOfLogMessages := 1
 	logger.Error("This ", "is ", "a ", "test.")
@@ -98,6 +100,39 @@ func (suite *LoggerTestSuite) TestLoggingWithContext() {
 
 	// FLuah will have no effect, but should not throw any errors.
 	logger.Flush()
+}
+
+func (suite *LoggerTestSuite) TestWithContextDoesNotMutateReceiver() {
+
+	shipper := newTestShipper().(*testShipper)
+	original := NewLogger(Debug, nil, shipper)
+
+	ctx := LogContextWithValues(context.Background(), map[string]string{"key": "value"})
+	derived := original.WithContext(ctx)
+
+	suite.NotSame(original, derived)
+
+	original.Error("from original")
+	suite.assertLogMessage(1, "Error: from original, Context: ", shipper)
+
+	derived.Error("from derived")
+	suite.assertLogMessage(2, "Error: from derived, Context: key:value", shipper)
+}
+
+func (suite *LoggerTestSuite) TestWithFieldsDoesNotMutateReceiver() {
+
+	shipper := newTestShipper().(*testShipper)
+	original := NewLogger(Debug, nil, shipper)
+
+	derived := original.WithFields(map[string]string{"key": "value"})
+
+	suite.NotSame(original, derived)
+
+	original.Error("from original")
+	suite.assertLogMessage(1, "Error: from original, Context: ", shipper)
+
+	derived.Error("from derived")
+	suite.assertLogMessage(2, "Error: from derived, Context: key:value", shipper)
 }
 
 func (suite *LoggerTestSuite) TestLogAndLogf() {
@@ -110,6 +145,41 @@ func (suite *LoggerTestSuite) TestLogAndLogf() {
 
 	logger.Logf(Error, "generic %s", "error")
 	suite.assertLogMessage(2, "Error: generic error, Context: ", shipper)
+}
+
+// TestConcurrentWithContextAndLog reproduces the GL-2/GL-3 scenario directly:
+// one shared base logger (the natural "one logger per service" pattern from
+// the README), with many goroutines deriving a per-request logger via
+// WithContext/WithFields and logging concurrently. Run with -race - before
+// the fix this raced on the shared context map (via the mutating WithContext
+// and the mutating LogzioJsonFormatter.format) and could misattribute a log
+// line to the wrong request's context.
+func (suite *LoggerTestSuite) TestConcurrentWithContextAndLog() {
+
+	shipper := newTestShipper().(*testShipper)
+	base := NewLogger(Debug, newLogzioJsonFormatter(), shipper)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			requestID := fmt.Sprintf("req-%d", n)
+			ctx := LogContextWithValues(context.Background(), map[string]string{"requestid": requestID})
+			perRequest := base.WithContext(ctx).WithFields(map[string]string{"seq": fmt.Sprintf("%d", n)})
+			perRequest.Info("handling request")
+		}(i)
+	}
+	wg.Wait()
+
+	// The shared base logger's own context must still be empty - none of the
+	// derived, per-request loggers should have leaked their fields back into it.
+	baseHandler, ok := base.(*LogHandler)
+	suite.True(ok)
+	suite.Empty(baseHandler.context.values)
+
+	suite.Len(shipper.messages, goroutines)
 }
 
 func (suite *LoggerTestSuite) assertLogMessage(expectedNumberOfLogMessages int, expectedMessage string, in *testShipper) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -135,6 +135,27 @@ func (suite *LoggerTestSuite) TestWithFieldsDoesNotMutateReceiver() {
 	suite.assertLogMessage(2, "Error: from derived, Context: key:value", shipper)
 }
 
+func (suite *LoggerTestSuite) TestWithContextMergesRatherThanReplaces() {
+
+	// Regression test: WithContext used to fully replace the receiver's
+	// context, so chaining WithFields(...).WithContext(ctx) silently dropped
+	// base-level fields (e.g. a namespace set once on a shared logger).
+	shipper := newTestShipper().(*testShipper)
+	base := NewLogger(Debug, nil, shipper).WithFields(map[string]string{"namespace": "auth-service"})
+
+	ctx := LogContextWithValues(context.Background(), map[string]string{"requestid": "abc-123"})
+	requestLogger := base.WithContext(ctx)
+
+	requestLogger.Error("handling request")
+	suite.assertLogMessage(1, "Error: handling request, Context: namespace:auth-service,requestid:abc-123", shipper)
+
+	// Values from ctx win on key conflicts.
+	overrideCtx := LogContextWithValues(context.Background(), map[string]string{"namespace": "overridden"})
+	overridden := base.WithContext(overrideCtx)
+	overridden.Error("conflict")
+	suite.assertLogMessage(2, "Error: conflict, Context: namespace:overridden", shipper)
+}
+
 func (suite *LoggerTestSuite) TestLogAndLogf() {
 
 	shipper := newTestShipper().(*testShipper)

--- a/test_utils.go
+++ b/test_utils.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/aws/aws-lambda-go/lambdacontext"
 	config "github.com/tommzn/go-config"
 	utils "github.com/tommzn/go-utils"
 )
 
-// testShipper is a mock for testing with an internal message stack.
+// testShipper is a mock for testing with an internal message stack. Guarded by
+// a mutex so it can be shared across goroutines in concurrency tests, same as
+// the real shippers.
 type testShipper struct {
+	mu       sync.Mutex
 	messages []string
 }
 
@@ -20,6 +24,8 @@ func newTestShipper() LogShipper {
 }
 
 func (shipper *testShipper) send(message string) {
+	shipper.mu.Lock()
+	defer shipper.mu.Unlock()
 	shipper.messages = append(shipper.messages, message)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -7,12 +7,14 @@ import (
 	"github.com/aws/aws-lambda-go/lambdacontext"
 )
 
-// WithNameSpace appends passed namespace as log context
+// WithNameSpace returns a new Logger with passed namespace appended as log context.
+// The passed logger is left unchanged.
 func WithNameSpace(logger Logger, namespace string) Logger {
-	return AppendContextValues(logger, map[string]string{LogCtxNamespace: namespace})
+	return logger.WithFields(map[string]string{LogCtxNamespace: namespace})
 }
 
-// WithK8sContext appends kubernetes values from environment variables as context
+// WithK8sContext returns a new Logger with kubernetes values from environment variables
+// appended as context. The passed logger is left unchanged.
 // At the moment following environment variables are supported:
 //	K8S_NODE_NAME 	- Node name
 //	K8S_POD_NAME	- Pod name
@@ -25,22 +27,21 @@ func WithK8sContext(logger Logger) Logger {
 	if pod, ok := os.LookupEnv("K8S_POD_NAME"); ok {
 		logContextValues[LogCtxK8sPod] = pod
 	}
-	return AppendContextValues(logger, logContextValues)
+	return logger.WithFields(logContextValues)
 }
 
-// appendContextValues adds passed values to context fo given logger.
+// AppendContextValues returns a new Logger with passed values added to its context.
+// The passed logger is left unchanged.
 func AppendContextValues(logger Logger, values map[string]string) Logger {
-	if logHandler, ok := logger.(*LogHandler); ok {
-		logHandler.context.AppendValues(values)
-	}
-	return logger
+	return logger.WithFields(values)
 }
 
-// AppendFromLambdaContext appends some values from given context, e.g. a request id,
-// to current log context if passed context is a AWS Lambda context.
+// AppendFromLambdaContext returns a new Logger with some values from given context,
+// e.g. a request id, added to its log context if passed context is an AWS Lambda context.
+// The passed logger is left unchanged.
 func AppendFromLambdaContext(logger Logger, ctx context.Context) Logger {
 	if lambdaCtx, ok := lambdacontext.FromContext(ctx); ok {
-		return AppendContextValues(logger, map[string]string{LogCtxRequestId: lambdaCtx.AwsRequestID})
+		return logger.WithFields(map[string]string{LogCtxRequestId: lambdaCtx.AwsRequestID})
 	}
 	return logger
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -57,7 +57,14 @@ func (suite *UtilsTestSuite) TestAppendContextValues() {
 	context2 := make(map[string]string)
 	context2["test-3"] = "val2"
 	logger = AppendContextValues(logger, context2)
-	suite.Len(logHandler.context.values, 2)
+
+	// AppendContextValues returns a new Logger rather than mutating the one
+	// passed in, so the original logHandler reference above is unaffected.
+	suite.Len(logHandler.context.values, 1)
+
+	logHandler2, ok2 := logger.(*LogHandler)
+	suite.True(ok2)
+	suite.Len(logHandler2.context.values, 2)
 }
 
 func (suite *UtilsTestSuite) TestAppendFromLambdaContext() {


### PR DESCRIPTION
## Summary

Applies GL-2, GL-3, GL-4 from the earlier findings review. **This is a breaking change** to the `Logger` interface: `WithContext(context.Context)` is now `WithContext(context.Context) Logger`.

### GL-2 - `WithContext` mutated a shared logger in place
Two goroutines calling `WithContext(ctx)` then logging on the same `*LogHandler` could interleave and misattribute a log line to the wrong request's context - a real hazard for the "one logger per service" pattern the README itself showed. `WithContext` now returns a new `*LogHandler` sharing the same formatter/shipper but with its own context. Migration:
```go
// before
logger.WithContext(ctx)
// after
logger = logger.WithContext(ctx)
```

### GL-3 - `LogContextWithValues` mutated the caller's map
`AppendValues` wrote the parent context's fields directly into the caller-supplied map (aliased, not copied). Both `LogContextWithValues` and `AppendValues` now clone before merging. Added a regression test reproducing the original repro.

### GL-4 - no inline structured key/value logging
Added `Logger.WithFields(map[string]string) Logger`. `WithNameSpace`, `WithK8sContext`, `AppendContextValues`, `AppendFromLambdaContext` are rewritten on top of it instead of type-asserting into `*LogHandler` - they now work for any `Logger` implementation.

### Found while implementing (not one of the three, but load-bearing for them)
- `LogzioJsonFormatter.format()` used to write `loglevel`/`timestamp`/`message` directly into `logContext.values` - the same map instance a `*LogHandler` holds for every message it logs. That's a concurrent map write the moment two goroutines log through the same logger at once. Now builds its own copy.
- `LogHandler`'s `RWMutex` is gone - `logLevel`/`context` are set once at construction and never modified afterward, so there's nothing left for a lock to protect.
- Fixed copy-paste doc-comment typos on `Infof`/`Info`/`Debugf`/`Debug` (previously described as `Errorf`/`Error`).

### Testing
Added `TestConcurrentWithContextAndLog`, run under `-race`: many goroutines deriving per-request loggers off one shared base logger and logging concurrently - the actual scenario GL-2/GL-3 described. It caught a real race on first run (in `testShipper`, the test mock itself - hardened with a mutex).

`go build ./...`, `go vet ./...`, `go test ./...`, `go test ./... -race` - all pass.

**Not fixed here**: running the full suite under `-race` surfaced a pre-existing, unrelated data race in the `LogzioShipper` test suite (confirmed present on `main` before this change too). Flagging separately rather than folding an unrelated fix into this PR.

GL-1 (AWS SDK dependency weight) is deliberately not addressed here - tracked separately.